### PR TITLE
Update Bloomberg sftp host.

### DIFF
--- a/R/BdlConnection.R
+++ b/R/BdlConnection.R
@@ -24,7 +24,7 @@ BdlConnection <- function(user,
   
     #sftp <- FALSE #libcurl doesn't support SFTP
     if (sftp) {
-      host <- 'dlsftp.bloomberg.com'
+      host <- 'sftp.bloomberg.com'
       port <- 30206
       protocol <- 'sftp'
     } else { 


### PR DESCRIPTION
Recently (some time in 2021 it seems) Bloomberg changed the Data License sftp host from **dl**sftp.bloomberg.com to sftp.bloomberg.com. dlsftp.bloomberg.com still seems to work in some instances, but sftp.bloomberg.com seems to work more reliably.